### PR TITLE
Fixes #80 by capturing the exception if the server is unreachable

### DIFF
--- a/grails-app/controllers/docker/registry/web/RepositoryController.groovy
+++ b/grails-app/controllers/docker/registry/web/RepositoryController.groovy
@@ -9,17 +9,20 @@ class RepositoryController {
 
     def index() {
         def registryToRepo = [:]
+        def registryReachable = [:]
         Registry.all.each { registry ->
             try {
               registryToRepo.put(registry, repositoryService.index(registry))
+              registryReachable.put(registry, true);
 
             } catch (errorRetrievingReposFromRegistry) {
-              registry.setAsUnreachable();
               registryToRepo.put(registry, [])
+              registryReachable.put(registry, false);
               log.error("The registry ${registry.toUrl()} is unreachable")
             }
         }
-        render view: "index", model: [registryToRepoMap: registryToRepo]
+ 
+        render view: "index", model: [registryToRepoMap: registryToRepo, reachable: registryReachable]
     }
 
     def show(final int registryId, final String repoName, final String tag, final String imgId) {

--- a/grails-app/domain/docker/registry/web/Registry.groovy
+++ b/grails-app/domain/docker/registry/web/Registry.groovy
@@ -9,11 +9,6 @@ class Registry {
     String username
     String password
 
-    /**
-     * Whether the registry is reachable or not.
-     */
-    transient boolean unreachable = false
-
     def repositoryService
 
     static constraints = {
@@ -21,7 +16,7 @@ class Registry {
         password nullable: true
     }
 
-    static transients = ['toUrl', 'repositories', 'ping', 'fromUrl', 'setAsUnreachable']
+    static transients = ['toUrl', 'repositories', 'ping', 'fromUrl']
 
     def toUrl() {
         def urlString = "http://${this.host}:${this.port}/${this.apiVersion}"
@@ -30,13 +25,6 @@ class Registry {
             else urlString = urlString.replace("://", "://$username@")
         }
         urlString
-    }
-
-    /**
-     * Sets the unreachable value to false in case the registry is unreachable during search.
-     */
-    def setAsUnreachable() {
-        unreachable = true
     }
 
     def getRepositories() {

--- a/grails-app/views/repository/index.gsp
+++ b/grails-app/views/repository/index.gsp
@@ -9,7 +9,12 @@
 
 <g:set var="multipleRegistries" value="${registryToRepoMap.size() > 1}"/>
 <g:each in="${registryToRepoMap}" var="entry">
-    <h3>Registry ${entry.key.host} <g:if test="${entry.key.unreachable}"><font color="#eb6864">(Unreachable)</font></g:if></h3>
+    <h3>Registry ${entry.key.host}</h3>
+    <g:if test="${!reachable.get(entry.key)}">
+      <div class="alert alert-dismissable alert-danger">
+        <strong>Oh snap!</strong> This server is Unreachable!
+      </div>
+    </g:if>
 
     <table id="imgTbl" class="table table-striped table-hover">
         <thead>


### PR DESCRIPTION
This commit fixes #80, the problem by verifying if the search throws an
exception, properly handling it to return an empty list instead.
In addition, the rendering page will display the information about
which Registry URL is unreachable, so that helps admins to properly
handle the problem.
-   modified:   grails-app/controllers/docker/registry/web/RepositoryController.groovy
- Handling the case when the repositoryService.index fails because
  the server is unreachable. If that's the case, just return an
  empty list and print an error message for further debugging/monitoring.
-   modified:   grails-app/domain/docker/registry/web/Registry.groovy
- Adding a transient property "unreachable" for rendering purpose.
- Adding the transient method "setAsUnreachable" that's set in the controller.
- Adding the method implementation to just set it as unreachable.
-   modified:   grails-app/views/repository/index.gsp
- Printing the warning message "(Unreachable) to the header of the repository
  in case the server can't be reached.
