### PR TITLE
Include local source in Dockerfile and add .dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.*.swp
+.git
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,29 @@
-FROM ubuntu:14.04
+FROM    ubuntu:14.04
 
-RUN apt-get install tomcat7 openjdk-7-jdk
+# Install java and tomcat
+RUN     apt-get update && apt-get install -y tomcat7 openjdk-7-jdk
+RUN     mkdir /var/lib/h2 && chmod a+rw /var/lib/h2
+RUN     rm -rf /var/lib/tomcat7/webapps/*
+ENV     JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
 
-RUN mkdir /var/lib/h2
+# Install grails and project dependencies
+WORKDIR /work
+ADD     grailsw /work/grailsw
+ADD     wrapper /work/wrapper
+ADD     application.properties /work/application.properties
+ADD     grails-app/conf/BuildConfig.groovy /work/grails-app/conf/BuildConfig.groovy
+RUN     ./grailsw help
 
-RUN chmod a+rw /var/lib/h2
+# Add project files and build a war
+ADD     . /work
+RUN     ./grailsw war
+RUN     cp target/docker-registry-ui-*.war /var/lib/tomcat7/webapps/ROOT.war
 
-RUN rm -rf /var/lib/tomcat7/webapps/*
+# Update catalina configuration
+WORKDIR /usr/share/tomcat7
+RUN     sed -i '1iexport CATALINA_OPTS=" -Djava.security.egd=file:/dev/./urandom "' bin/catalina.sh
 
-VOLUME ["/var/lib/h2/", "/var/lib/tomcat7"]
-
-ADD http://atc.gd/docker-registry-ui.war /var/lib/tomcat7/webapps/ROOT.war
-
-CMD sed -i '1iexport CATALINA_OPTS=" -Djava.security.egd=file:/dev/./urandom "' bin/catalina.sh && bin/catalina.sh run
+EXPOSE  8080
+VOLUME  ["/var/lib/h2/", "/var/lib/tomcat7"]
+ENV     CATALINA_BASE /var/lib/tomcat7
+CMD     bin/catalina.sh run


### PR DESCRIPTION
Resolves #97

Building on your change in the 0.96.0 branch.

I split up the `ADD` steps so that you don't have to repeat the install of grails and all the dependency libraries unless one of the dependencies actually changes. This way, when you make a code changes, re-building the war in the docker image is nearly as fast as it would be locally (just re-compiling the files).
