### PR TITLE
Added an env variable option for adding an alias to /etc/hosts

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,3 +1,6 @@
+if [ -n "$ETC_HOSTS_ALIAS" ]; then
+  ex -sc 's/$/ '${ETC_HOSTS_ALIAS}'/|w|q' /etc/hosts
+fi
 if [ -n "$APP_CONTEXT" ]; then
   mv /var/lib/tomcat7/webapps/ROOT.war /var/lib/tomcat7/webapps/${APP_CONTEXT}.war
 fi


### PR DESCRIPTION
This simply appends the passed in ETC_HOSTS_ALIAS value to the last entry in /etc/hosts
(which when used with link, ex: --link reg:reg, will allow the registry UI to
appropriately talk to the registry on the same host)

This change was needed in order for our use case (registry and registry UI containers on same host) to work.

example usage: docker run -p 8080:8080 -e ETC_HOSTS_ALIAS=example.com --link reg:reg docker-registry-web
